### PR TITLE
Making Jenkins instances deployed over HTTPS work

### DIFF
--- a/lib/janky/job_creator.rb
+++ b/lib/janky/job_creator.rb
@@ -93,7 +93,7 @@ module Janky
         user = uri.user
         pass = uri.password
         http = Net::HTTP.new(uri.host, uri.port)
-
+        http.use_ssl=true if (uri.scheme.casecmp("https") == 0)
         post = Net::HTTP::Post.new("/createItem?name=#{name}")
         post.basic_auth(user, pass) if user && pass
         post["Content-Type"] = "application/xml"


### PR DESCRIPTION
My Jenkins instance is running on CloudBees DEV@cloud, the Jenkins instance is available over HTTPS. There is bug in the Janky job_creator.rb where it fails to talk over https and hubot jenkins command shows this stack trace https://gist.github.com/1504508. 

The fix is simple, for both exist? and run method, set http.use_ssl=true based on scheme. I verified this fix to work with Jenkins instance running over HTTPS.
