### PR TITLE
Update lib/janky/hubot.rb with location of janky.coffee

### DIFF
--- a/lib/janky/hubot.rb
+++ b/lib/janky/hubot.rb
@@ -4,7 +4,7 @@ module Janky
   # builds.
   #
   # The client side implementation is at
-  # <https://github.com/github/hubot/blob/master/scripts/ci.js>
+  # <https://github.com/github/hubot-scripts/blob/master/src/scripts/janky.coffee>
   class Hubot < Sinatra::Base
     register Helpers
 


### PR DESCRIPTION
Old: https://github.com/github/hubot/blob/master/scripts/ci.js
New: https://github.com/github/hubot-scripts/blob/master/src/scripts/janky.coffee
