### PR TITLE
Return a 400 Bad Request for invalid payloads

### DIFF
--- a/lib/janky/builder/receiver.rb
+++ b/lib/janky/builder/receiver.rb
@@ -10,7 +10,7 @@ module Janky
         elsif payload.completed?
           Build.complete(payload.id, payload.green?)
         else
-          return Rack::Response.new("Invalid", 402).finish
+          return Rack::Response.new("Bad Request", 400).finish
         end
 
         Rack::Response.new("OK", 201).finish


### PR DESCRIPTION
The builder is returning a `402 Payment Required` when the payload is invalid. This changes it to returns a `400 Bad Request`.
