### PR TITLE
ensure that github owner names that include dashes are handled correctly

### DIFF
--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -86,14 +86,14 @@ module Janky
     #
     # Returns the user name as a String.
     def github_owner
-      uri[/github\.com[\/:](\w+)\//] && $1
+      uri[/github\.com[\/:]([a-zA-Z0-9\-_]+)\//] && $1
     end
 
     # Name of this repository on GitHub.
     #
     # Returns the name as a String.
     def github_name
-      uri[/github\.com[\/:](\w+)\/([a-zA-Z0-9\-_]+)/] && $2
+      uri[/github\.com[\/:]([a-zA-Z0-9\-_]+)\/([a-zA-Z0-9\-_]+)/] && $2
     end
 
     # Name of the Campfire room receiving build notifications.

--- a/test/janky_test.rb
+++ b/test/janky_test.rb
@@ -268,4 +268,17 @@ class JankyTest < Test::Unit::TestCase
     assert hubot_build("janky", "master").not_found?
     assert hubot_build("github", "master").not_found?
   end
+
+  test "github owner is parsed correctly" do
+    repo = Janky::Repository.setup("github/janky")
+    assert_equal "github", repo.github_owner 
+    assert_equal "janky", repo.github_name
+  end
+
+  test "owner with a dash is parsed correctly" do
+    repo = Janky::Repository.setup("digital-science/central-ftp-manage")
+    assert_equal "digital-science", repo.github_owner
+    assert_equal "central-ftp-manage", repo.github_name
+  end
+
 end


### PR DESCRIPTION
Hi,
our organisation name has a dash in it, which was causing 404s when we tried to create hooks in github.
This fixes that.
-Thom
