### PR TITLE
Make chat env var comparison uppercase

### DIFF
--- a/lib/janky.rb
+++ b/lib/janky.rb
@@ -155,7 +155,7 @@ module Janky
     chat_name = settings["JANKY_CHAT"] || "campfire"
     chat_settings = {}
     settings.each do |key, value|
-      if key =~ /^JANKY_CHAT_#{chat_name}_/
+      if key =~ /^JANKY_CHAT_#{chat_name.upcase}_/
         chat_settings[key] = value
       end
     end


### PR DESCRIPTION
The chat adapters want env vars in uppercase, e.g. JANKY_CHAT_CAMPFIRE_ACCOUNT, but the adapter names are lower case "campfire". This means that the comparison never works, and the adapters aren't initialized with the correct credentials.

The result is an error message because e.g. the adapter doesn't know the subdomain:

```
2012-01-30T18:35:39+00:00 app[web.1]: !! Unexpected error while processing request: the scheme https does not accept registry part: .campfirenow.com (or bad hostname?)
```
