### PR TITLE
Fetch default room from settings hash

### DIFF
--- a/lib/janky.rb
+++ b/lib/janky.rb
@@ -159,7 +159,7 @@ module Janky
         chat_settings[key] = value
       end
     end
-    chat_room = ["JANKY_CHAT_DEFAULT_ROOM"] ||
+    chat_room = settings["JANKY_CHAT_DEFAULT_ROOM"] ||
       settings["JANKY_CAMPFIRE_DEFAULT_ROOM"]
     if settings["JANKY_CAMPFIRE_DEFAULT_ROOM"]
       warn "JANKY_CAMPFIRE_DEFAULT_ROOM is deprecated. Please use " \


### PR DESCRIPTION
The campfire integration is not working unless you're using the deprecated JANKY_CAMPFIRE_DEFAULT_ROOM option.
