### PR TITLE
Google Bot

### DIFF
--- a/lib/janky/github/receiver.rb
+++ b/lib/janky/github/receiver.rb
@@ -45,6 +45,8 @@ module Janky
         signature = @request.env["HTTP_X_HUB_SIGNATURE"].split("=").last
 
         signature == OpenSSL::HMAC.hexdigest(digest, @secret, data)
+      rescue
+        false
       end
 
       def payload


### PR DESCRIPTION
Google tried to hit me here.

```
2012-02-11T00:41:51+00:00 app[web.1]: ERROR: NoMethodError - undefined method `split' for nil:NilClass2012-02-11T00:41:51+00:00 app[web.1]:          app janky
2012-02-11T00:41:51+00:00 app[web.1]:      session   {}2012-02-11T00:41:51+00:00 app[web.1]:       method  GET
2012-02-11T00:41:51+00:00 app[web.1]:   user_agent Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)2012-02-11T00:41:51+00:00 app[web.1]:       params   {}
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/janky-0.9.10/lib/janky/github/receiver.rb:45:in `valid_signature?'
2012-02-11T00:41:51+00:00 app[web.1]:     referrer     
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/rack-1.4.1/lib/rack/builder.rb:134:in `call'2012-02-11T00:41:51+00:00 app[web.1]:    remote_ip 66.249.72.5
2012-02-11T00:41:51+00:00 app[web.1]: 
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/janky-0.9.10/lib/janky/github/receiver.rb:24:in `call!'
2012-02-11T00:41:51+00:00 app[web.1]:          url http://danky.herokuapp.com/_github
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/janky-0.9.10/lib/janky/github/receiver.rb:18:in `call'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/rack-1.4.1/lib/rack/urlmap.rb:49:in `call'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/rack-1.4.1/lib/rack/urlmap.rb:64:in `block in call'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/rack-1.4.1/lib/rack/urlmap.rb:49:in `each'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/janky-0.9.10/lib/janky/exception.rb:44:in `call'
2012-02-11T00:41:51+00:00 heroku[router]: Error H13 (Connection closed without response) -> GET danky.herokuapp.com/_github dyno=web.1 queue= wait= service= status=503 bytes=
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/connection.rb:78:in `pre_process'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/connection.rb:78:in `catch'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/connection.rb:80:in `block in pre_process'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/connection.rb:38:in `receive_data'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/connection.rb:53:in `process'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:256:in `run_machine'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:256:in `run'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/server.rb:159:in `start'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/backends/base.rb:61:in `start'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/bin/thin:6:in `<top (required)>'2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/controllers/controller.rb:86:in `start'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/runner.rb:185:in `run_command'2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/bin/thin:19:in `load'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/thin-1.3.1/lib/thin/runner.rb:151:in `run!'
2012-02-11T00:41:51+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/bin/thin:19:in `<main>'
```
