### PR TITLE
"auth/github/callback" shouldn't match a 'repo/branch' url.

### DIFF
--- a/lib/janky/app.rb
+++ b/lib/janky/app.rb
@@ -58,7 +58,7 @@ module Janky
       mustache :index
     end
 
-    get %r{\/([-_\.0-9a-zA-Z]+)\/([-_\.a-zA-z0-9\/]+)} do |repo_name, branch|
+    get %r{^(?!\/auth\/github\/callback)\/([-_\.0-9a-zA-Z]+)\/([-_\.a-zA-z0-9\/]+)} do |repo_name, branch|
       repo = find_repo(repo_name)
       authorize_repo(repo)
 


### PR DESCRIPTION
Introduced by 6c4b8726ff9243ea49e0d0e0cd7bcb91d0c81623.
