### PR TITLE
Documentation correction - adding the hipchat gem to the Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Required settings:
 Installation:
 
 * Add `require "janky/chat_service/hipchat"` to the `config.ru` file.
-* `echo 'gem "hipchat", "~>0.4" >> Gemfile'`
+* `echo 'gem "hipchat", "~>0.4"' >> Gemfile`
 * `bundle`
 * `git commit -am "install hipchat"`
 


### PR DESCRIPTION
Correct the command to add the hipchat gem to Gemfile.

Previously resulted in the command being echoed instead of being appended to the Gemfile.
