### PR TITLE
Support configurable page title

### DIFF
--- a/lib/janky/templates/layout.mustache
+++ b/lib/janky/templates/layout.mustache
@@ -10,7 +10,7 @@
 </head>
 <body class="{{page_class}}">
   <div id="wrapper">
-    <h2 id="logo"><a href="{{root}}/">Janky Hubot</a></h2>
+    <h2 id="logo"><a href="{{root}}/">{{title}}</a></h2>
 
     <div class="content">
       <div class="inside">

--- a/lib/janky/views/layout.rb
+++ b/lib/janky/views/layout.rb
@@ -4,7 +4,7 @@ module Janky
     class Layout < Mustache
 
       def title
-        "Janky Hubot"
+        ENV["PAGE_TITLE"] || "Janky Hubot"
       end
 
       def page_class


### PR DESCRIPTION
If your bot is called something other than Hubot, the janky page should probably reflect that.
