### PR TITLE
Fixes Build model on Postgres

### DIFF
--- a/lib/janky/build.rb
+++ b/lib/janky/build.rb
@@ -5,11 +5,7 @@ module Janky
 
     default_scope do
       columns = (column_names - ["output"]).map do |column_name|
-        if Build.connection.adapter_name == "MySQL"
-          "`#{table_name}`.`#{column_name}`"
-        else
-          "\"#{table_name}\".\"#{column_name}\""
-        end
+        arel_table[column_name]
       end
 
       select(columns)


### PR DESCRIPTION
This fixes a SQL quote syntax error on Postgres.

I was getting the following error message after I upgraded to the latest version:

```
!! Unexpected error while processing request: PG::Error: ERROR:  syntax error at or near "."
2012-06-13T03:44:41+00:00 app[web.1]: LINE 1: SELECT  `builds`.`id`, `builds`.`green`, `builds`.`url`, `bu...
2012-06-13T03:44:41+00:00 app[web.1]:                         ^
2012-06-13T03:44:41+00:00 app[web.1]: : SELECT  `builds`.`id`, `builds`.`green`, `builds`.`url`, `builds`.`compare`, `builds`.`started_at`, `builds`.`completed_at`, `builds`.`commit_id`, `builds`.`branch_id`, `builds`.`created_at`, `builds`.`updated_at`, `builds`.`room_id` FROM "builds"  WHERE "builds"."commit_id" = 491 ORDER BY "builds"."id" DESC LIMIT 1
```
