### PR TITLE
Destroy branches and builds when a repo is destroyed.

### DIFF
--- a/lib/janky/branch.rb
+++ b/lib/janky/branch.rb
@@ -1,7 +1,7 @@
 module Janky
   class Branch < ActiveRecord::Base
     belongs_to :repository
-    has_many :builds
+    has_many :builds, :dependent => :destroy
 
     # Is this branch green?
     #

--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -1,7 +1,7 @@
 module Janky
   class Repository < ActiveRecord::Base
-    has_many :branches
-    has_many :commits
+    has_many :branches, :dependent => :destroy
+    has_many :commits, :dependent => :destroy
     has_many :builds, :through => :branches
 
     replicate_associations :builds, :commits, :branches


### PR DESCRIPTION
Simple PR. Since there doesn't seem to be a way to remove a job from Janky, I'd like to atleast be able to:

```
heroku run bash
bundle exec irb
require 'janky'
Janky.setup ENV
Janky::Repository.find(2).destroy
```
