### PR TITLE
Create jobs with human-readable names

### DIFF
--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -182,14 +182,9 @@ module Janky
 
     # Calculate the name of the Jenkins job.
     #
-    # Returns a String hash of this Repository name and uri.
+    # Returns the String name.
     def job_name
-      md5 = Digest::MD5.new
-      md5 << name
-      md5 << uri
-      md5 << job_config_path.read
-      md5 << builder.callback_url.to_s
-      md5.hexdigest
+      "#{github_owner}-#{github_name}"
     end
   end
 end


### PR DESCRIPTION
This changes Janky to create Jenkins jobs named in the form `OWNER-REPOSITORY` instead of crazy MD5 hashes, because seeing a dashboard like this is no fun:

![zomg all the hashes](https://github-images.s3.amazonaws.com/skitch/Screen_Shot_2012-08-19_at_11.28.39-20120819-112857.png)

It doesn't look like the Jenkins API has a way to rename jobs, so migrating existing jobs doesn't seem possible.
