### PR TITLE
Link to the specific Janky build instead of the branch page

### DIFF
--- a/lib/janky/notifier/chat_service.rb
+++ b/lib/janky/notifier/chat_service.rb
@@ -12,7 +12,7 @@ module Janky
           build.branch_name,
           status,
           build.duration,
-          build.branch_url
+          build.web_url
         ]
 
         ::Janky::ChatService.speak(message, build.room_id, {:color => color})


### PR DESCRIPTION
Our PropaneHax have been updated to remove this explicit link as well.
