### PR TITLE
Display output URLs as hyperlinks in Hipchat

### DIFF
--- a/lib/janky/chat_service/hipchat.rb
+++ b/lib/janky/chat_service/hipchat.rb
@@ -14,10 +14,11 @@ module Janky
       end
 
       def speak(message, room_id, options = {})
-        options.merge!({
+        default = {
           :color => "yellow",
           :message_format => "text"
-        }) { |key, value, default| value }
+        }
+        options = default.merge(options)
         @client[room_id].send(@from, message, options)
       end
 


### PR DESCRIPTION
By default the output URLs are displayed in Hipchat as plain text and must be copy pasted into a browser. This change allows Hipchat to transform them into clickable hyperlinks (by default, you can turn it off).

![example](https://f.cloud.github.com/assets/591257/7674/a6e8f1d6-4434-11e2-800a-1e52bb14fb82.png)

_Tech Notes_
Hipchat now allows API messages to be processed similar to user messages by passing `message_format: text" in the API call.

[Relevant Hipchat Blog Post](http://blog.hipchat.com/2012/07/10/a-simple-but-powerful-change-to-our-messaging-api/)
[Relevant Hipchat API Docs](https://www.hipchat.com/docs/api/method/rooms/message)
