### PR TITLE
use readable job_name that is also unique

### DIFF
--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -189,7 +189,6 @@ module Janky
       md5 << uri
       md5 << job_config_path.read
       md5 << builder.callback_url.to_s
-      md5.hexdigest
       "#{github_owner}-#{github_name}-#{md5.hexdigest}"
     end
   end


### PR DESCRIPTION
"#{github_owner}/#{github_name}-#{md5.hexdigest}" (note fwd-slash) would be better but not sure how much jenkins would appreciate a / in the name...
