### PR TITLE
Remove job.xml.erb contents from MD5 id generation

### DIFF
--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -187,7 +187,6 @@ module Janky
       md5 = Digest::MD5.new
       md5 << name
       md5 << uri
-      md5 << job_config_path.read
       md5 << builder.callback_url.to_s
       "#{github_owner}-#{github_name}-#{md5.hexdigest}"
     end


### PR DESCRIPTION
MD5 should not include the job file contents

There is enough uniqueness in job name generation without resorting
to reading job file contents to affect the MD5 id.

This is pretty problematic if minor tweaks are made to the Jenkins
job.xml.erb templates.  Consider changes such as modifying email
notifications, or enabling Chuck Norris, etc.

We refresh jobs automatically as part of an automated deployment,
but this will result in new MD5 job ids created in Jenkins.  This
is bad news, especially when there are many jobs.  All jobs are
now effectively duplicated and the history is now no longer
correlated between the runs, etc.
