### PR TITLE
Allow updating existing job configurations

### DIFF
--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -187,7 +187,6 @@ module Janky
       md5 = Digest::MD5.new
       md5 << name
       md5 << uri
-      md5 << job_config_path.read
       md5 << builder.callback_url.to_s
       "#{github_owner}-#{github_name}-#{md5.hexdigest}"
     end


### PR DESCRIPTION
Quick synopsis... 
- We automate our deploys with Capistrano.
- Capistrano maintains a hash of Github repo to name.
- After a succesful deploy, the jobs are refreshed automatically based on this hash.  We essentially just whack  `localhost:5000/_hubot/setup?nwo=Owner/Repo&name=name` for each job.

Unfortunately, as it exists, Janky wants to create a new Jenkins job every time the corresponding `job.xml.erb` is modified and attached to a repository.  IMHO, the existing config should instead be updated using the Jenkins REST API.  The current setup leaves a big mess inside of Jenkins with extraneous jobs all over the place.

Fortunately the checks were already in place to see if a job exists, so I simply modified the code to update an existing job config if the job exists on the server already.

We're using this in production now.
