### PR TITLE
Add support for forks / pull request events

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ We **strongly recommend** backing up your Janky database before upgrading.
 
 The general process is to then upgrade the gem, and then run migrate.  Here is how
 you do that on a local box you have access to (this process will differ for Heroku):
-    
+
     cd [PATH-TO-JANKY]
     gem update janky
     rake db:migrate
@@ -144,6 +144,20 @@ Required settings:
 * `JANKY_GITHUB_HOOK_SECRET`: Secret used to sign hook requests from
   GitHub.
 * `JANKY_CHAT_DEFAULT_ROOM`: Chat room where notifications are sent by default.
+
+Optional Github event settings:
+
+* `JANKY_GITHUB_EVENT_TYPES`: A comma separated list of event types that Janky
+will respond to from GitHub.  Presently, `pull_request` and `push` are supported,
+and the default value responds to both `pull_request,push`.  If you follow the
+[fork & pull][] model, and have additional Jenkins jobs that are initiated by
+pushes to the master branch (i.e. those initiated directly by GitHub and
+received by Jenkins), then it is recommended to set this to `pull_request`.  If
+everyone is working on a shared repo, then `push` will likely be sufficient.
+See [Event Types][] for more details on the different types / payloads.
+
+[fork&pull]: https://help.github.com/articles/using-pull-requests
+[Event Types]: http://developer.github.com/v3/activity/events/types/
 
 Optional database settings:
 
@@ -278,7 +292,7 @@ Contributing
 
 Fork the [Janky repository on GitHub](https://github.com/github/janky) and
 send a Pull Request.  Note that any changes to behavior without tests will
-be rejected.  If you are adding significant new features, please add both 
+be rejected.  If you are adding significant new features, please add both
 tests and documentation.
 
 Copying

--- a/lib/janky.rb
+++ b/lib/janky.rb
@@ -138,10 +138,22 @@ module Janky
       raise Error, "JANKY_GITHUB_API_URL must have a trailing slash"
     end
     hook_url = base_url + "_github"
+    valid_events = ['pull_request', 'push']
+    if settings.key?("JANKY_GITHUB_EVENT_TYPES")
+      events = settings["JANKY_GITHUB_EVENT_TYPES"].split(',') \
+        .each { |e| e.strip! }
+    else
+      events = valid_events
+    end
+    extra = events.select { |e| !valid_events.include?(e) }
+    if events.nil? or events.empty? or !extra.empty?
+      raise Error, "JANKY_GITHUB_EVENT_TYPES must have #{valid_events.join(' or ')}"
+    end
     Janky::GitHub.setup(
       settings["JANKY_GITHUB_USER"],
       settings["JANKY_GITHUB_PASSWORD"],
       settings["JANKY_GITHUB_HOOK_SECRET"],
+      events,
       hook_url,
       api_url,
       git_host

--- a/lib/janky/builder/runner.rb
+++ b/lib/janky/builder/runner.rb
@@ -19,9 +19,10 @@ module Janky
 
       def json_params
         Yajl.dump(:parameter => [
-          { :name => "JANKY_SHA1",   :value => @build.sha1 },
-          { :name => "JANKY_BRANCH", :value => @build.branch_name },
-          { :name => "JANKY_ID",     :value => @build.id }
+          { :name => "JANKY_SHA1",       :value => @build.sha1 },
+          { :name => "JANKY_BRANCH",     :value => @build.branch_name },
+          { :name => "JANKY_ID",         :value => @build.id },
+          { :name => "JANKY_COMMIT_URL", :value => @build.commit_url }
         ])
       end
 

--- a/lib/janky/github.rb
+++ b/lib/janky/github.rb
@@ -5,22 +5,24 @@ module Janky
     # user     - API user as a String.
     # password - API password as a String.
     # secret   - Secret used to sign hook requests from GitHub.
+    # events   - Event types that Janky builds for - "pull_request" and "push"
     # hook_url - String URL that handles Post-Receive requests.
     # api_url  - GitHub API URL as a String. Requires a trailing slash.
     # git_host - Hostname where git repos are hosted. e.g. "github.com"
     #
     # Returns nothing.
-    def self.setup(user, password, secret, hook_url, api_url, git_host)
+    def self.setup(user, password, secret, events, hook_url, api_url, git_host)
       @user = user
       @password = password
       @secret = secret
+      @events = events
       @hook_url = hook_url
       @api_url = api_url
       @git_host = git_host
     end
 
     class << self
-      attr_reader :secret, :git_host
+      attr_reader :secret, :events, :git_host
     end
 
     # URL of the GitHub website.
@@ -35,7 +37,7 @@ module Janky
     #
     # Returns a GitHub::Receiver.
     def self.receiver
-      @receiver ||= Receiver.new(@secret)
+      @receiver ||= Receiver.new(@secret, @events)
     end
 
     # Fetch repository details.

--- a/lib/janky/github.rb
+++ b/lib/janky/github.rb
@@ -108,6 +108,36 @@ module Janky
       Yajl.load(response.body)
     end
 
+    # Fetch commit details for the given pull request.
+    #
+    # nwo    - qualified "owner/repo" name.
+    # number - number of the pull request
+    #
+    # Example
+    #
+    #   commit("github/janky", 5)
+    #   => { "commit" => {
+    #          "author" => {
+    #            "name"  => "Simon Rozet",
+    #            "email" => "sr@github.com",
+    #          },
+    #          "message" => "document and clean up Branch#build_for_head",
+    #        }
+    #      }
+    #
+    # Returns the commit Hash.
+    def self.pull_request_commit(nwo, number)
+      response = api.pull_request_commit(nwo, number)
+
+      if response.code != "200"
+        Exception.push_http_response(response)
+        raise Error, "Failed to get pull request commit"
+      end
+
+      Yajl.load(response.body)
+    end
+
+
     # Create a Post-Receive hook for the given repository.
     # http://developer.github.com/v3/repos/hooks/#create-a-hook
     #

--- a/lib/janky/github/api.rb
+++ b/lib/janky/github/api.rb
@@ -56,6 +56,14 @@ module Janky
         http.request(request)
       end
 
+      def pull_request_commit(nwo, number)
+        path    = build_path("repos/#{nwo}/pulls/#{number}/commits")
+        request = Net::HTTP::Get.new(path)
+        request.basic_auth(@user, @password)
+
+        http.request(request)
+      end
+
       def build_path(path)
         if path[0] == ?/
           URI.join(@url, path[1..-1]).path
@@ -71,7 +79,8 @@ module Janky
             "url"          => url,
             "secret"       => secret,
             "content_type" => "json"
-          }
+          },
+          "events" => ["push", "pull_request"]
         }
       end
 

--- a/lib/janky/github/payload.rb
+++ b/lib/janky/github/payload.rb
@@ -2,22 +2,30 @@ module Janky
   module GitHub
     class Payload
       def self.parse(json)
-        parsed = PayloadParser.new(json)
-        new(parsed.uri, parsed.branch, parsed.head, parsed.pusher,
-            parsed.commits,
-            parsed.compare)
+        new(PayloadParser.new(json))
       end
 
-      def initialize(uri, branch, head, pusher, commits, compare)
-        @uri     = uri
-        @branch  = branch
-        @head    = head
-        @pusher  = pusher
-        @commits = commits
-        @compare = compare
+      def set_pull_request_commits(commits)
+        @parsed.set_pull_request_commits(commits)
+        @commits = @parsed.commits
       end
 
-      attr_reader :uri, :branch, :head, :pusher, :commits, :compare
+      def initialize(parsed)
+        @parsed         = parsed
+        @uri            = parsed.uri
+        @branch         = parsed.branch
+        @head           = parsed.head
+        @pusher         = parsed.pusher
+        @commits        = parsed.commits
+        @compare        = parsed.compare
+        @pull_request   = parsed.pull_request?
+        @nwo            = parsed.nwo
+        @pull_number    = parsed.pull_number
+        @pull_action    = parsed.pull_action
+      end
+
+      attr_reader :uri, :branch, :head, :pusher, :commits, :compare,
+        :pull_request, :nwo, :pull_number, :pull_action
 
       def head_commit
         @commits.detect do |commit|

--- a/lib/janky/github/payload_parser.rb
+++ b/lib/janky/github/payload_parser.rb
@@ -5,26 +5,101 @@ module Janky
         @payload = Yajl.load(json)
       end
 
+      def pull_request?
+        @payload.has_key?('pull_request')
+      end
+
+      def pull_number
+        if @payload.has_key?('number')
+          @payload['number']
+        end
+      end
+
+      def pull_action
+        if @payload.has_key?('action')
+          @payload['action']
+        end
+      end
+
       def pusher
-        @payload["pusher"]["name"]
+        if pull_request?
+          @payload["sender"]["login"]
+        else
+          @payload["pusher"]["name"]
+        end
       end
 
       def head
-        @payload["after"]
+        if pull_request?
+          @payload["pull_request"]["head"]["sha"]
+        else
+          @payload["after"]
+        end
+      end
+
+      def base
+        if pull_request?
+          @payload["pull_request"]["base"]["sha"]
+        else
+          @payload["before"]
+        end
       end
 
       def compare
-        @payload["compare"]
+        if pull_request?
+          #HACK: event only has template in API style
+          @payload["pull_request"]["head"]["repo"]["compare_url"]
+            .gsub('//api.github.com/', '//github.com/')
+            .gsub('/repos/', '/')
+            .gsub('/commits/', '/commit/')
+            .gsub('{base}', base[0..11])
+            .gsub('{head}', head[0..11])
+        else
+          @payload["compare"]
+        end
+      end
+
+      def set_pull_request_commits(commits)
+        @payload["commits"] = commits
       end
 
       def commits
-        @payload["commits"].map do |commit|
+        if pull_request?
+          map_pull_request_commits(@payload["commits"] || [])
+        else
+          map_merge_commits(@payload["commits"])
+        end
+      end
+
+      def map_merge_commits(hash)
+        hash.map do |commit|
           GitHub::Commit.new(
             commit["id"],
             commit["url"],
             commit["message"],
             normalize_author(commit["author"]),
             commit["timestamp"]
+          )
+        end
+      end
+
+      def map_pull_request_commits(hash)
+        head_nwo = @payload["pull_request"]["head"]["repo"]["full_name"]
+        base_nwo = @payload["pull_request"]["base"]["repo"]["full_name"]
+        hash.map do |commit|
+          # HACK: because GitHub keeps messing with the API results
+          details = commit["commit"] || commit
+          GitHub::Commit.new(
+            commit["sha"],
+            #HACK: event only has an API style url
+            commit["url"]
+              .gsub('//api.github.com/', '//github.com/')
+              .gsub('/repos/', '/')
+              .gsub('/commits/', '/commit/')
+              .gsub(base_nwo, head_nwo),
+            details["message"],
+            normalize_author(details["author"]),
+            details["author"]["date"]
           )
         end
       end
@@ -37,24 +112,47 @@ module Janky
         end
       end
 
+      def nwo
+        repository = @payload["repository"]
+        if pull_request?
+          owner = repository["owner"]["login"]
+        else
+          owner = repository["owner"]["name"]
+        end
+
+        "#{owner}/#{repository["name"]}"
+      end
+
       def uri
         if uri = @payload["uri"]
           return uri
         end
 
-        repository = @payload["repository"]
-
-        if repository["private"]
-          "git@#{GitHub.git_host}:#{URI(repository["url"]).path[1..-1]}"
+        if pull_request?
+          repository = @payload["repository"]
+          if repository["private"]
+            repository["ssh_url"].gsub(/\.git$/, '')
+          else
+            repository["git_url"].gsub(/\.git$/, '')
+          end
         else
-          uri = URI(repository["url"])
-          uri.scheme = "git"
-          uri.to_s
+          repository = @payload["repository"]
+          if repository["private"]
+            "git@#{GitHub.git_host}:#{URI(repository["url"]).path[1..-1]}"
+          else
+            uri = URI(repository["url"])
+            uri.scheme = "git"
+            uri.to_s
+          end
         end
       end
 
       def branch
-        @payload["ref"].split("refs/heads/").last
+        if pull_request?
+          @payload["pull_request"]["head"]["ref"]
+        else
+          @payload["ref"].split("refs/heads/").last
+        end
       end
     end
   end

--- a/lib/janky/github/receiver.rb
+++ b/lib/janky/github/receiver.rb
@@ -29,6 +29,10 @@ module Janky
           return Rack::Response.new("Invalid Content-Type", 400).finish
         end
 
+        if payload.pull_request and payload.pull_action == 'closed'
+          return Rack::Response.new("Ignored", 400).finish
+        end
+
         if !payload.head_commit
           return Rack::Response.new("Ignored", 400).finish
         end
@@ -54,6 +58,11 @@ module Janky
 
       def payload
         @payload ||= GitHub::Payload.parse(data)
+        if @payload.pull_request
+          commits = GitHub.pull_request_commit(@payload.nwo, @payload.pull_number)
+          @payload.set_pull_request_commits(commits)
+        end
+        @payload
       end
 
       def data


### PR DESCRIPTION
Accept pull req events / pass JANKY_COMMIT_URL
- JANKY_COMMIT_URL is now pushed to Jenkins jobs as parameter
- Hook registration establishes pull_request event
- Payload parser now speaks pull request event
- Add API support for repos/#{nwo}/pulls/#{number}/commits
