### PR TITLE
Provide additional parameter in ci setup / Hubot endpoint to accept template

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ anything unless it needs to. It takes an optional name argument:
 
     hubot ci setup github/janky janky-ruby1.9.2
 
+It also takes an optional template name argument:
+
+    hubot ci setup github/janky janky-ruby1.9.2 ruby-build
+
 All branches are built automatically on push. Disable auto build with:
 
     hubot ci toggle janky
@@ -114,7 +118,7 @@ We **strongly recommend** backing up your Janky database before upgrading.
 
 The general process is to then upgrade the gem, and then run migrate.  Here is how
 you do that on a local box you have access to (this process will differ for Heroku):
-    
+
     cd [PATH-TO-JANKY]
     gem update janky
     rake db:migrate
@@ -234,8 +238,10 @@ For more control you can add a `script/cibuild` at the root of your
 repository for Jenkins to execute instead.
 
 For total control, whole Jenkins' `config.xml` files can be associated
-with Janky builds. Given a build called `windows`, Janky will try
-`config/jobs/windows.xml.erb` before falling back to the default
+with Janky builds. Given a build called `windows` and a template name
+of `psake`, Janky will try `config/jobs/psake.xml.erb` to use a template,
+`config/jobs/windows.xml.erb` to try the job name if the template does
+not exit,  before finally falling back to the default
 configuration, `config/jobs/default.xml.erb`. After updating or adding
 a custom config, run `hubot ci setup` again to update the Jenkins
 server.
@@ -278,7 +284,7 @@ Contributing
 
 Fork the [Janky repository on GitHub](https://github.com/github/janky) and
 send a Pull Request.  Note that any changes to behavior without tests will
-be rejected.  If you are adding significant new features, please add both 
+be rejected.  If you are adding significant new features, please add both
 tests and documentation.
 
 Copying

--- a/lib/janky/hubot.rb
+++ b/lib/janky/hubot.rb
@@ -12,11 +12,12 @@ module Janky
     post "/setup" do
       nwo  = params["nwo"]
       name = params["name"]
-      repo = Repository.setup(nwo, name)
+      tmpl = params["template"]
+      repo = Repository.setup(nwo, name, tmpl)
 
       if repo
         url  = "#{settings.base_url}#{repo.name}"
-        [201, "Setup #{repo.name} at #{repo.uri} | #{url}"]
+        [201, "Setup #{repo.name} at #{repo.uri} with #{repo.job_config_path.basename} | #{url}"]
       else
         [400, "Couldn't access #{nwo}. Check the permissions."]
       end
@@ -111,6 +112,7 @@ module Janky
 ci build janky
 ci build janky/fix-everything
 ci setup github/janky [name]
+ci setup github/janky name template
 ci toggle janky
 ci rooms
 ci set room janky development


### PR DESCRIPTION
When there are lots of jobs that have more than one standard build configuration, the current match up of `job` to `job.xml.erb`, with only a single fallback of `default.xml.erb` is inconvenient.  If there is a secondary standard build configuration, then every job that uses that secondary build configuration has to now have a `name.xml.erb` file instead of being able to share a single file.

I would like to see an additional parameter at the `_hubot` route named `template` in addition to `nwo` and `name`.

At the moment when the command is issued from Hubot to Janky, you may perform a `ci setup owner/repo name` -- and then that name is matched to `config/name.xml.erb` to find a custom template if it exists.  I would like to see the command extended to `ci setup owner/repo name template` that would look for `config/template.xml.erb`

Changes would have to be made at
- https://github.com/github/janky/blob/master/lib/janky/hubot.rb#L15 - To accept the post parameter `template`
- https://github.com/github/janky/blob/master/lib/janky/repository.rb#L164 - To accept / use the new `template` param to find the file on disk
- https://github.com/github/hubot-scripts/blob/master/src/scripts/janky.coffee#L91 - To modify the `setup` command to accept an optional `template` parameter as the final parameter

I think that's it to make this work... thoughts? /cc @rsanheim
