### PR TITLE
Update Content-Type check in `Janky::GitHub::Receiver`

### DIFF
--- a/lib/janky/github/receiver.rb
+++ b/lib/janky/github/receiver.rb
@@ -25,6 +25,10 @@ module Janky
           return Rack::Response.new("Invalid signature", 403).finish
         end
 
+        if @request.content_type != "application/json"
+          return Rack::Response.new("Invalid Content-Type", 400).finish
+        end
+
         if !payload.head_commit
           return Rack::Response.new("Ignored", 400).finish
         end
@@ -57,10 +61,6 @@ module Janky
       end
 
       def data!
-        if @request.content_type != "application/json"
-          return Rack::Response.new("Invalid Content-Type", 400).finish
-        end
-
         body = ""
         @request.body.each { |chunk| body << chunk }
         body


### PR DESCRIPTION
Receiving an actual invalid content_type would try to pass the Rack::Response to
the `PayloadParser` and throw an exception.
