### PR TITLE
Allow + in branch names

### DIFF
--- a/lib/janky/hubot.rb
+++ b/lib/janky/hubot.rb
@@ -81,7 +81,7 @@ module Janky
     end
 
     # Get the status of a repository's branch.
-    get %r{\/([-_\.0-9a-zA-Z]+)\/([-_\.a-zA-z0-9\/]+)} do |repo_name, branch_name|
+    get %r{\/([-_\.0-9a-zA-Z]+)\/([-_\+\.a-zA-z0-9\/]+)} do |repo_name, branch_name|
       limit = params["limit"]
 
       repo   = find_repo(repo_name)


### PR DESCRIPTION
We've started using `+` in branch names to indicate longer running integration branches.  This allows the build status url to match branch names with a +.
