### PR TITLE
List all the queued builds for a given branch

### DIFF
--- a/lib/janky/app.rb
+++ b/lib/janky/app.rb
@@ -44,6 +44,12 @@ module Janky
       mustache :index
     end
 
+    get "/branch/:branch_name" do |branch_name|
+      authorize_index
+      @builds = find_queued_builds_for(branch_name).first(50)
+      mustache :index
+    end
+
     get "/:build_id/output" do |build_id|
       @build = Build.select(:output).find(build_id)
       authorize_repo(@build.repo)

--- a/lib/janky/helpers.rb
+++ b/lib/janky/helpers.rb
@@ -13,5 +13,12 @@ module Janky
 
       repo
     end
+
+    def find_queued_builds_for(branch_name)
+      branches = Branch.find(:all, :conditions => ["name = ?", branch_name])
+      halt(404, "Unknown branch: #{branch_name}") if branches.empty?
+
+      branches.map(&:queued_builds).flatten
+    end
   end
 end

--- a/test/janky_test.rb
+++ b/test/janky_test.rb
@@ -156,6 +156,10 @@ class JankyTest < Test::Unit::TestCase
     assert get("/github/master").ok?
     assert get("/github/strato").ok?
 
+    assert get("/branch/master").ok?
+    assert get("/branch/not_found").not_found?
+    assert get("/branch/not_found").body.include? "Unknown branch: not_found"
+
     assert get("#{Janky::Build.last.id}/output").ok?
   end
 


### PR DESCRIPTION
This change enable users to list all the builds for a given branch by accessing `/branch/:branch_name`.
