### PR TITLE
Truncate MD5 digests in job names to 12 characters

### DIFF
--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -189,7 +189,7 @@ module Janky
       md5 << uri
       md5 << job_config_path.read
       md5 << builder.callback_url.to_s
-      "#{github_owner}-#{github_name}-#{md5.hexdigest}"
+      "#{github_owner}-#{github_name}-#{md5.hexdigest[0,12]}"
     end
   end
 end

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -14,6 +14,11 @@ class RepositoryTest < Test::Unit::TestCase
     assert_match /\Agithub-janky-.+/, repo.job_name
   end
 
+  test "job name includes truncated MD5 digest" do
+    repo = Janky::Repository.setup("github/janky")
+    assert_match /-[0-9a-f]{12}$/, repo.job_name
+  end
+
   test "github owner is parsed correctly" do
     repo = Janky::Repository.setup("github/janky")
     assert_equal "github", repo.github_owner


### PR DESCRIPTION
On Windows, file paths are limited to 260 characters (including the drive letter and null terminator). Projects get checked out to directories with names like:

```
C:\<jenkins root>\workspace\<job name>
```

Including a 32-character MD5 digest (plus the repo owner and name) in the job name significantly reduces the number of characters left for use by the files in the repository. (For example, for brightray/libchromiumcontent the job name is 61 characters long. When combined with the drive letter, null terminator, and `\workspace\`, only 184 characters are left for paths within the repository itself.)

So now we truncate MD5 digests in job names to just the 12 most significant hex digits. This is enough for building brightray/libchromiumcontent (for now at least).
