### PR TITLE
Include custom names in Jenkins job names

### DIFF
--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -189,7 +189,7 @@ module Janky
       md5 << uri
       md5 << job_config_path.read
       md5 << builder.callback_url.to_s
-      "#{github_owner}-#{github_name}-#{md5.hexdigest[0,12]}"
+      "#{name}-#{md5.hexdigest[0,12]}"
     end
   end
 end

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -9,9 +9,14 @@ class RepositoryTest < Test::Unit::TestCase
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  test "job name includes github owner and project" do
+  test "job name includes repo name" do
     repo = Janky::Repository.setup("github/janky")
-    assert_match /\Agithub-janky-.+/, repo.job_name
+    assert_match /\Ajanky-.+/, repo.job_name
+  end
+
+  test "job name includes custom name" do
+    repo = Janky::Repository.setup("github/janky", "janky2")
+    assert_match /\Ajanky2-.+/, repo.job_name
   end
 
   test "job name includes truncated MD5 digest" do


### PR DESCRIPTION
Previously, if you set up the same repo multiple times (e.g., to build it on different platforms) like so:

```
hubot ci setup github/janky janky18
hubot ci setup github/janky janky19
```

...you'd end up with two nearly-indistinguishable Jenkins jobs with names like:

```
github-janky-2bce842af1a9
github-janky-e89e28098c6a
```

With this change, the jobs will be easier to tell apart:

```
janky18-2bce842af1a9
janky19-e89e28098c6a
```

As an added bonus, the job names will usually be a bit shorter, giving us still more breathing room on Windows before running into file path length limits.
