### PR TITLE
Latest version of sinatra-auth-github

### DIFF
--- a/janky.gemspec
+++ b/janky.gemspec
@@ -17,7 +17,7 @@ EOL
   # runtime
   s.add_dependency "rake", "~>0.9.2"
   s.add_dependency "sinatra", "~>1.3"
-  s.add_dependency "sinatra_auth_github", "~>0.7.0"
+  s.add_dependency "sinatra_auth_github", "~>0.13.3"
   s.add_dependency "mustache", "~>0.11"
   s.add_dependency "yajl-ruby", "~>1.1.0"
   s.add_dependency "activerecord", "~>3.2.0"


### PR DESCRIPTION
Get on newer sinatra-auth-github gem and fixup intermittent 403s from github.com.

I'm assuming the problem is with the user-agent usage in different places that's become required in the last year or so. We happily rolled out this upgrade to our servers earlier today.
