### PR TITLE
Refresh the build list every 5 seconds.

### DIFF
--- a/lib/janky/public/javascripts/application.js
+++ b/lib/janky/public/javascripts/application.js
@@ -1,3 +1,10 @@
 $(function(){
+  function refresh() {
+    $('.builds').load(location.pathname + ' .builds', function() {
+      $('.relatize').relatize()
+    })
+  }
+
+  setInterval(refresh, 5000)
   $('.relatize').relatize()
 })


### PR DESCRIPTION
We just added this to our fork to refresh the build list every 5 seconds to get new queued builds and updated statuses. I'm opening this in case of anyone else running Janky finds this valuable and wants to use it or wants to suggest anything.
