### PR TITLE
Always delete and recreate hooks on setup

### DIFF
--- a/lib/janky/github.rb
+++ b/lib/janky/github.rb
@@ -116,7 +116,6 @@ module Janky
     # Returns the newly created hook URL as String when successful.
     # Raises an Error for any other response.
     def self.hook_create(nwo)
-      hook_delete(nwo)
       response = api.create(nwo, @secret, @hook_url)
 
       if response.code == "201"
@@ -127,15 +126,23 @@ module Janky
       end
     end
 
+    # Check existance of a hook.
+    # http://developer.github.com/v3/repos/hooks/#get-single-hook
+    #
+    # url - Hook URL as a String.
+    def self.hook_exists?(url)
+      api.get(url).code == "200"
+    end
+
     # Delete a post-receive hook for the given repository.
     #
-    # nwo - qualified "owner/repo" name.
+    # hook_url - The repository's hook_url
     #
     # Returns true or raises an exception.
-    def self.hook_delete(nwo)
-      response = api.delete(nwo)
+    def self.hook_delete(url)
+      response = api.delete(url)
 
-      if response.code == "201"
+      if response.code == "204"
         true
       else
         Exception.push_http_response(response)

--- a/lib/janky/github/api.rb
+++ b/lib/janky/github/api.rb
@@ -16,7 +16,7 @@ module Janky
         http.request(request)
       end
 
-      def delete(nwo)
+      def delete(hook_url)
         path    = build_path(URI(hook_url).path)
         request = Net::HTTP::Delete.new(path)
         request.basic_auth(@user, @password)

--- a/lib/janky/repository.rb
+++ b/lib/janky/repository.rb
@@ -143,6 +143,10 @@ module Janky
     #
     # Returns nothing.
     def setup_hook
+      if self.hook_url? && GitHub.hook_exists?(self.hook_url)
+        GitHub.hook_delete(self.hook_url)
+      end
+
       url = GitHub.hook_create("#{github_owner}/#{github_name}")
       update_attributes!(:hook_url => url)
     end


### PR DESCRIPTION
Just what it says. Should fix weirdness when repos get renamed or hooks manually recreated.
