### PR TITLE
Mark Builds as Pending when Queued 

### DIFF
--- a/lib/janky/build_request.rb
+++ b/lib/janky/build_request.rb
@@ -29,6 +29,7 @@ module Janky
       if !current_build || (current_build && current_build.red?)
         if @repo.enabled?
           build.run
+          Notifier.queued(build)
         end
       end
     end

--- a/lib/janky/notifier.rb
+++ b/lib/janky/notifier.rb
@@ -9,6 +9,15 @@ module Janky
       @adapter = Multi.new(Array(notifiers))
     end
 
+    # Called whenever a build is queued
+    #
+    # build - the Build record.
+    #
+    # Returns nothing
+    def self.queued(build)
+      adapter.queued(build)
+    end
+
     # Called whenever a build starts.
     #
     # build - the Build record.

--- a/lib/janky/notifier/github_status.rb
+++ b/lib/janky/notifier/github_status.rb
@@ -12,6 +12,14 @@ module Janky
         @api_url = URI(api_url)
       end
 
+      # Create a Pending Status for the Commit when it is queued.
+      def queued(build)
+        repo   = build.repo_nwo
+        path  = "repos/#{repo}/statuses/#{build.sha1}"
+
+        post(path, "pending", build.web_url, "Build ##{build.number} queued")
+      end
+
       # Create a Pending Status for the Commit when it starts.
       def started(build)
         repo   = build.repo_nwo

--- a/lib/janky/notifier/multi.rb
+++ b/lib/janky/notifier/multi.rb
@@ -6,6 +6,12 @@ module Janky
         @notifiers = notifiers
       end
 
+      def queued(build)
+        @notifiers.each do |notifier|
+          notifier.queued(build) if notifier.respond_to?(:queued)
+        end
+      end
+
       def started(build)
         @notifiers.each do |notifier|
           notifier.started(build) if notifier.respond_to?(:started)


### PR DESCRIPTION
Adds functionality for notifiers to receive a "queued" notification. 

Also adds a notification to github when this is queued.

Closes #189
