### PR TITLE
Send a Context to Github with Janky Status Updates

### DIFF
--- a/lib/janky.rb
+++ b/lib/janky.rb
@@ -203,8 +203,9 @@ module Janky
     ChatService.setup(chat_name, chat_settings, chat_room)
 
     if token = settings["JANKY_GITHUB_STATUS_TOKEN"]
+      context = settings["JANKY_GITHUB_STATUS_CONTEXT"]
       Notifier.setup([
-        Notifier::GithubStatus.new(token, api_url),
+        Notifier::GithubStatus.new(token, api_url, context),
         Notifier::ChatService
       ])
     else

--- a/lib/janky/notifier/github_status.rb
+++ b/lib/janky/notifier/github_status.rb
@@ -7,9 +7,10 @@ module Janky
     # "success" or "failure" when the build is complete.
     class GithubStatus
       # Initialize with an OAuth token to POST Statuses with
-      def initialize(token, api_url)
+      def initialize(token, api_url, context = nil)
         @token = token
         @api_url = URI(api_url)
+        @context = context
       end
 
       # Create a Pending Status for the Commit when it is queued.
@@ -52,11 +53,18 @@ module Janky
         post["Content-Type"] = "application/json"
         post["Authorization"] = "token #{@token}"
 
-        post.body = {
+        body = {
           :state => status,
           :target_url => url,
           :description => desc,
-        }.to_json
+        }
+
+        unless @context.nil?
+          post["Accept"] = "application/vnd.github.she-hulk-preview+json"
+          body[:context] = @context
+        end
+
+        post.body = body.to_json
 
         http.request(post)
       end


### PR DESCRIPTION
This will send a "context" variable with status updates to Github. 

It will send "ci/janky" by default, but can be configured with the `JANKY_GITHUB_STATUS_CONTEXT` environment variable.
