### PR TITLE
Set reconnect=true on ActiveRecord db connection

### DIFF
--- a/lib/janky.rb
+++ b/lib/janky.rb
@@ -109,7 +109,8 @@ module Janky
       :username  => database.user,
       :password  => database.password,
       :host      => database.host,
-      :port      => database.port
+      :port      => database.port,
+      :reconnect => true,
     }
     if socket = settings["JANKY_DATABASE_SOCKET"]
       connection[:socket] = socket


### PR DESCRIPTION
Fixes errors like: `Mysql2::Error: closed MySQL connection`

/cc @bhuga @jbarnette 
