### PR TITLE
Fix payload.completed? to work with new jenkins version

### DIFF
--- a/lib/janky/builder/payload.rb
+++ b/lib/janky/builder/payload.rb
@@ -40,7 +40,7 @@ module Janky
       end
 
       def completed?
-        @phase == "FINISHED"
+        @phase == "FINISHED" || @phase == "FINALIZED"
       end
 
       def green?


### PR DESCRIPTION
New versions on Jenkins send FINALIZED instead of FINISHED as the build phase.

Without this change the builds not update the status.
