### PR TITLE
Add hubot chat service to gemspec

### DIFF
--- a/janky.gemspec
+++ b/janky.gemspec
@@ -57,6 +57,7 @@ lib/janky/builder/runner.rb
 lib/janky/chat_service.rb
 lib/janky/chat_service/campfire.rb
 lib/janky/chat_service/hipchat.rb
+lib/janky/chat_service/hubot.rb
 lib/janky/chat_service/slack.rb
 lib/janky/chat_service/mock.rb
 lib/janky/commit.rb


### PR DESCRIPTION
I was unable to have janky load the hubot chat service until adding ``` lib/janky/chat_service/hubot.rb ``` to the gemspec.

Otherwise, adding ``` require "janky/chat_service/hubot" ``` to the config/environment.rb file fails with an error.