### PR TITLE
Fix Chat Notifications

### DIFF
--- a/lib/janky/build.rb
+++ b/lib/janky/build.rb
@@ -243,6 +243,10 @@ module Janky
       self.class.base_url + "#{repo_name}/#{branch_name}"
     end
 
+    def room_id
+      repository.room_id
+    end
+
     def repo_id
       repository.id
     end


### PR DESCRIPTION
Previously `room_id` was being passed to `speak` as undefined and the notification send was failing.

I was seeing this while using the hipchat chat service.