### PR TITLE
Use path building methods to prevent errors

### DIFF
--- a/lib/janky.rb
+++ b/lib/janky.rb
@@ -95,10 +95,6 @@ module Janky
     database = URI(settings["DATABASE_URL"])
     adapter  = database.scheme == "postgres" ? "postgresql" : database.scheme
     encoding = database.scheme == "postgres" ? "unicode" : "utf8"
-    if settings["JANKY_BASE_URL"][-1] != ?/
-      warn "JANKY_BASE_URL must have a trailing slash"
-      settings["JANKY_BASE_URL"] = settings["JANKY_BASE_URL"] + "/"
-    end
     base_url = URI(settings["JANKY_BASE_URL"]).to_s
     Build.base_url = base_url
 

--- a/lib/janky/builder/runner.rb
+++ b/lib/janky/builder/runner.rb
@@ -30,7 +30,7 @@ module Janky
       end
 
       def create_url
-        URI("#{@base_url}job/#{@build.repo_job_name}/build")
+        URI.join(@base_url, "job/#{@build.repo_job_name}/build")
       end
 
       def context_push

--- a/lib/janky/chat_service/hubot.rb
+++ b/lib/janky/chat_service/hubot.rb
@@ -28,14 +28,14 @@ module Janky
         uri  = @url
         user = uri.user
         pass = uri.password
-        path = uri.path
+        path = File.join(uri.path, "janky")
 
         http = Net::HTTP.new(uri.host, uri.port)
         if uri.scheme == "https"
           http.use_ssl = true
         end
 
-        post = Net::HTTP::Post.new("#{path}/janky")
+        post = Net::HTTP::Post.new(path)
         post.basic_auth(user, pass) if user && pass
         post["Content-Type"] = "application/json"
         post.body = {:message => message, :room => room}.to_json

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,7 @@ class Test::Unit::TestCase
   def environment
     env = default_environment
     ENV.each do |key, value|
-      if key =~ /^JANKY_/
+      if key =~ /^JANKY_/ || key == "DATABASE_URL"
         env[key] = value
       end
     end


### PR DESCRIPTION
I was setting up a janky installation recently and was struggling to work out why it wasn't posting notifications to Hubot. It turned out that it was because I had a trailing slash on the `JANKY_HUBOT_URL` environment variable, which leads to double slashes in the called URLs (unlike `JANKY_BUILDER_DEFAULT`, which requires the trailing slash).

I've amended some of the string paths to use path building APIs.