### PR TITLE
Update the test runner to work with newer rubies

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,5 +1,3 @@
 #!/usr/bin/env ruby
 require 'test/unit'
 exit Test::Unit::AutoRunner.run(true, nil, Dir.glob("test/*_test.rb"))
-
-# testrb ./test/*_test.rb

--- a/script/test
+++ b/script/test
@@ -1,2 +1,5 @@
-#!/bin/sh
-testrb ./test/*_test.rb
+#!/usr/bin/env ruby
+require 'test/unit'
+exit Test::Unit::AutoRunner.run(true, nil, Dir.glob("test/*_test.rb"))
+
+# testrb ./test/*_test.rb


### PR DESCRIPTION
Ruby versions after 2.1.x remove the `testrb` script that used to shift with Ruby by default. Due to its removal, copy the contents of the script from an older version of Ruby and use it in our `script/test` script so that we can upgrade Ruby without having to switch out the test framework and setup.