### PR TITLE
Install a newer version of test-unit

### DIFF
--- a/janky.gemspec
+++ b/janky.gemspec
@@ -29,6 +29,7 @@ EOL
   s.add_development_dependency "shotgun", "~>0.9"
   s.add_development_dependency "thin", "~>1.2"
   s.add_development_dependency "mysql2", "~>0.3.0"
+  s.add_development_dependency "test-unit", "~>3.2.0"
 
   # test
   s.add_development_dependency "database_cleaner", "~>0.6"


### PR DESCRIPTION
Allows developers to upgrade to Ruby 2.2.x instead of being stuck on Ruby 2.1.x.

It even works with Ruby 2.3 :tada:

Doesn't work with Ruby 2.4 though :sob: but that's ok because I didn't really expect it to since we're on older version of libraries that haven't been updated yet.