### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ command:
 Required settings:
 
 * `JANKY_BASE_URL`: The application URL **with** a trailing slash. Example:
-  `http://mf-doom-42.herokuapp.com/`.
+  ``.
 * `JANKY_BUILDER_DEFAULT`: The Jenkins server URL **with** a trailing slash.
    Example: `http://jenkins.example.com/`. For basic auth, include the
    credentials in the URL: `http://user:pass@jenkins.example.com/`.


### PR DESCRIPTION
http://mf-doom-42.herokuapp.com/ can be takeover from Heroku because there is no app on it.